### PR TITLE
feat: medium-priority cleanup — error envelopes, type safety, import hygiene, CI

### DIFF
--- a/.github/workflows/main_projecte.yml
+++ b/.github/workflows/main_projecte.yml
@@ -59,6 +59,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
 
       # 🛠️ Local Build Section (Optional)
       # The following section in your workflow is designed to catch build issues early on the client side, before deployment. This can be helpful for debugging and validation. However, if this step significantly increases deployment time and early detection is not critical for your workflow, you may remove this section to streamline the deployment process.
@@ -80,6 +81,13 @@ jobs:
           # Upgrade pip, setuptools, wheel first (ensures reliable builds)
           pip install --upgrade pip>=24.0 setuptools>=70.0 wheel>=0.41.0
           pip install -r backend/requirements.txt
+
+      - name: Run mypy on cleaned service modules
+        run: |
+          source antenv/bin/activate
+          pip install mypy
+          cd backend
+          mypy --ignore-missing-imports services/auth/ services/interview/scoring_service.py
 
       - name: Validate imports and app module
         run: |

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, HTTPException, Header, Query, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, HTTPException, Request, Header, Query, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import StreamingResponse, HTMLResponse, FileResponse, JSONResponse
@@ -771,10 +771,24 @@ try:
 except Exception as e:
     logging.warning(f"⚠️ Could not register admin router: {e}")
 
-#D
+def _error_json(code: str, message: str, status_code: int) -> JSONResponse:
+    return JSONResponse(status_code=status_code, content={"error": {"code": code, "message": message}})
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+    detail = exc.detail
+    if isinstance(detail, dict):
+        code = detail.get("code") or f"HTTP_{exc.status_code}"
+        message = detail.get("message") or str(detail)
+    else:
+        code = f"HTTP_{exc.status_code}"
+        message = str(detail) if detail else f"HTTP {exc.status_code}"
+    return _error_json(code, message, exc.status_code)
+
 
 @app.exception_handler(Exception)
-async def global_exception_handler(request, exc: Exception):
+async def global_exception_handler(request: Request, exc: Exception):
     """Catch-all handler: log the full traceback server-side, return sanitized error to client."""
     logging.exception(
         "Unhandled exception on %s %s: %s",
@@ -782,14 +796,10 @@ async def global_exception_handler(request, exc: Exception):
         request.url.path,
         exc,
     )
-    return JSONResponse(
-        status_code=500,
-        content={
-            "error": {
-                "code": "INTERNAL_ERROR",
-                "message": "An unexpected error occurred. Please try again.",
-            }
-        },
+    return _error_json(
+        "INTERNAL_ERROR",
+        "An unexpected error occurred. Please try again.",
+        500,
     )
 
 @app.get("/", include_in_schema=False)

--- a/backend/db/database.py
+++ b/backend/db/database.py
@@ -2,6 +2,7 @@
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker, declarative_base
 from sqlalchemy.engine import Engine
+from typing import Any, Dict
 import os
 import logging
 
@@ -19,9 +20,9 @@ def is_production_env() -> bool:
     return ENV == "production"
 
 # Azure PostgreSQL readiness configuration
-def _get_engine_config(database_url: str) -> dict:
+def _get_engine_config(database_url: str) -> Dict[str, Any]:
     """Get SQLAlchemy engine configuration based on database type."""
-    config = {}
+    config: Dict[str, Any] = {}
     
     if database_url.startswith("sqlite"):
         # SQLite-specific settings

--- a/backend/services/auth/middleware.py
+++ b/backend/services/auth/middleware.py
@@ -29,7 +29,7 @@ class AuthMiddleware:
         
         return None
 
-    def validate_and_extract(self, authorization_header: Optional[str], query_token: Optional[str]) -> Tuple[str, str, str]:
+    def validate_and_extract(self, authorization_header: Optional[str], query_token: Optional[str]) -> Tuple[str, str, Optional[str]]:
         """Validate token and extract claims."""
         token = self.extract_token(authorization_header, query_token)
         

--- a/backend/services/interview/jd_parser.py
+++ b/backend/services/interview/jd_parser.py
@@ -12,14 +12,7 @@ import os
 import re
 from typing import Any, Dict, List, Optional
 
-try:
-    from services.interview.llm_cache import get as cache_get, put as cache_put
-except Exception:
-    try:
-        from backend.services.interview.llm_cache import get as cache_get, put as cache_put
-    except Exception:
-        cache_get = lambda *a: None  # type: ignore
-        cache_put = lambda *a: None  # type: ignore
+from services.interview.llm_cache import get as cache_get, put as cache_put
 
 
 # ─── Domain keyword maps ──────────────────────────────────────────────────────

--- a/backend/services/interview/star_extractor.py
+++ b/backend/services/interview/star_extractor.py
@@ -12,14 +12,7 @@ import os
 import re
 from typing import Any, Dict, Optional
 
-try:
-    from services.interview.llm_cache import get as cache_get, put as cache_put
-except Exception:
-    try:
-        from backend.services.interview.llm_cache import get as cache_get, put as cache_put
-    except Exception:
-        cache_get = lambda *a: None  # type: ignore
-        cache_put = lambda *a: None  # type: ignore
+from services.interview.llm_cache import get as cache_get, put as cache_put
 
 # ─── Keyword fallback (original heuristics) ───────────────────────────────────
 

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -3,7 +3,7 @@ import { Container, Typography, Grid, Card, Box, CardContent, Button, Stack, Div
 import { useNavigate } from "react-router-dom";
 import { PlayArrow, Speed, Psychology, Assessment, TrendingUp } from "@mui/icons-material";
 import { useUser, useAuth } from "@clerk/clerk-react";
-import { authFetch } from "../utils/apiClient";
+import { authFetch, throwForResponse, getApiErrorMessage } from "../utils/apiClient";
 import { getApiBaseUrl } from "../utils/apiBaseUrl";
 import { formatInterviewTypeLabel } from "../utils/interviewTypeLabels";
 
@@ -32,24 +32,12 @@ export default function Dashboard() {
     setSyncStatus("syncing");
     try {
       const resp = await authFetch(`${API_BASE}/api/me`, token, { method: "GET" });
-      if (!resp.ok) {
-        const text = await resp.text();
-        let msg = `Backend returned ${resp.status}`;
-        try {
-          const data = JSON.parse(text);
-          msg = data.detail || msg;
-        } catch {
-          if (text) msg = text.slice(0, 120);
-        }
-        setSyncError(msg);
-        setSyncStatus("error");
-        return;
-      }
+      await throwForResponse(resp, { defaultMessage: "Failed to sync user with backend." });
       const data = await resp.json();
       setBackendUser(data);
       setSyncStatus("ok");
     } catch (err) {
-      setSyncError(err.message || "Failed to sync user with backend");
+      setSyncError(getApiErrorMessage(err, { defaultMessage: "Failed to sync user with backend." }));
       setSyncStatus("error");
     }
   }, [getToken, isLoaded]);
@@ -69,14 +57,11 @@ export default function Dashboard() {
         return;
       }
       const resp = await authFetch(`${API_BASE}/api/interview/reports`, token, { method: "GET" });
-      if (!resp.ok) {
-        const text = await resp.text();
-        throw new Error(text || `Failed to fetch history (${resp.status})`);
-      }
+      await throwForResponse(resp, { defaultMessage: "Failed to fetch interview history." });
       const data = await resp.json();
       setHistoryReports(Array.isArray(data) ? data : []);
     } catch (err) {
-      setHistoryError(err.message || "Failed to load interview history");
+      setHistoryError(getApiErrorMessage(err, { defaultMessage: "Failed to load interview history." }));
     } finally {
       setHistoryLoading(false);
     }


### PR DESCRIPTION
## Summary

- **Structured HTTP error responses** — new `@app.exception_handler(HTTPException)` wraps all HTTP errors in `{"error": {"code": "HTTP_<N>", "message": "..."}}` instead of FastAPI's raw `{"detail": "..."}`. Shared `_error_json()` helper eliminates duplicated envelope construction between both exception handlers.

- **Remove silent LLM-cache fallback** — `star_extractor.py` and `jd_parser.py` had a nested `try/except` that silently replaced `cache_get`/`cache_put` with no-op lambdas on any import failure, disabling the LLM cache with no log. Replaced with a direct import (server always runs `cd backend && uvicorn app:app`).

- **Type annotation fixes** — `_get_engine_config()` in `db/database.py` annotated as `Dict[str, Any]` (mypy inferred `dict[str, bool]` from first assignment). `validate_and_extract()` in `services/auth/middleware.py` corrected to `Tuple[str, str, Optional[str]]` — `candidate_id` is genuinely optional.

- **mypy in CI** — new step runs `mypy --ignore-missing-imports` on `services/auth/` and `services/interview/scoring_service.py`. Python setup step gains `cache: 'pip'` (Node already cached npm).

- **Dashboard.jsx** — replaced manual `resp.ok` checks and hand-rolled JSON parsing with `throwForResponse` + `getApiErrorMessage` from `apiClient.js`, matching the pattern already used in `PreInterviewForm`, `ReportPage`, and `AdminEntryPage`.

## Test plan

- [ ] CI mypy step passes (0 errors on targeted modules)
- [ ] `curl -H "Authorization: Bearer bogus" <app>/api/me` → `{"error": {"code": "HTTP_401", "message": "..."}}`
- [ ] Dashboard loads normally; error state shows clean message on backend failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)