### PR TITLE
Tests: route surface smoke coverage for API routes

### DIFF
--- a/backend/tests/test_route_surface_smoke.py
+++ b/backend/tests/test_route_surface_smoke.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+
+from backend import app as app_module
+
+
+SKIP_PATH_PREFIXES = (
+    "/openapi.json",
+    "/docs",
+    "/redoc",
+    "/static",
+    "/assets",
+    "/backend-static",
+)
+
+SKIP_EXACT_PATHS = {
+    "/",
+    "/favicon.ico",
+}
+
+
+def _iter_http_route_cases() -> Iterable[tuple[str, str]]:
+    for route in app_module.app.routes:
+        if not isinstance(route, APIRoute):
+            continue
+
+        path = route.path
+        if path in SKIP_EXACT_PATHS or path.startswith(SKIP_PATH_PREFIXES):
+            continue
+
+        methods = sorted((route.methods or set()) - {"HEAD", "OPTIONS"})
+        for method in methods:
+            yield (method, path)
+
+
+def _build_url(path: str) -> str:
+    # Replace path params with harmless placeholders.
+    # Example: /api/items/{item_id} -> /api/items/test
+    return re.sub(r"\{[^}]+\}", "test", path)
+
+
+def test_all_http_routes_respond_without_unhandled_server_errors():
+    client = TestClient(app_module.app)
+    cases = list(_iter_http_route_cases())
+    # Guard so this test catches accidental router unregistering.
+    assert len(cases) > 25
+
+    failures: list[str] = []
+    for method, path in cases:
+        url = _build_url(path)
+        kwargs = {"follow_redirects": False}
+        if method in {"POST", "PUT", "PATCH"}:
+            kwargs["json"] = {}
+
+        response = client.request(method, url, **kwargs)
+        if path == "/health" and response.status_code in {200, 503}:
+            continue
+        if response.status_code >= 500:
+            failures.append(f"{method} {path} -> {response.status_code}")
+
+    assert not failures, "Routes returning 5xx:\n" + "\n".join(failures)


### PR DESCRIPTION
## Summary
- add 
- iterate through all registered HTTP routes (excluding docs/static)
- issue method-correct smoke requests with placeholder path params
- fail if any route returns unhandled 5xx (health allows 200/503 based on dependency availability)
- assert route-case inventory is above a floor to catch accidental router drops

## Why
Provides broad regression coverage across route registration and request handling so endpoint-level breakages are caught quickly.

## Validation
- .                                                                        [100%]
=============================== warnings summary ===============================
.venv/lib/python3.14/site-packages/starlette/_utils.py:17: 112 warnings
backend/tests/test_route_surface_smoke.py: 67 warnings
  /Users/hchinnam/iceye-projects/copilot-worktrees/new_portfolio_2026/harisrujanc-effective-meme/evaluate-yourself/.venv/lib/python3.14/site-packages/starlette/_utils.py:17: DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead
    return asyncio.iscoroutinefunction(obj) or (

backend/app.py:451
  /Users/hchinnam/iceye-projects/copilot-worktrees/new_portfolio_2026/harisrujanc-effective-meme/evaluate-yourself/backend/app.py:451: DeprecationWarning: 
          on_event is deprecated, use lifespan event handlers instead.
  
          Read more about it in the
          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
          
    @app.on_event("startup")

.venv/lib/python3.14/site-packages/fastapi/applications.py:4547
.venv/lib/python3.14/site-packages/fastapi/applications.py:4547
  /Users/hchinnam/iceye-projects/copilot-worktrees/new_portfolio_2026/harisrujanc-effective-meme/evaluate-yourself/.venv/lib/python3.14/site-packages/fastapi/applications.py:4547: DeprecationWarning: 
          on_event is deprecated, use lifespan event handlers instead.
  
          Read more about it in the
          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
          
    return self.router.on_event(event_type)

backend/app.py:459
  /Users/hchinnam/iceye-projects/copilot-worktrees/new_portfolio_2026/harisrujanc-effective-meme/evaluate-yourself/backend/app.py:459: DeprecationWarning: 
          on_event is deprecated, use lifespan event handlers instead.
  
          Read more about it in the
          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
          
    @app.on_event("shutdown")

.venv/lib/python3.14/site-packages/fastapi/routing.py:211: 108 warnings
  /Users/hchinnam/iceye-projects/copilot-worktrees/new_portfolio_2026/harisrujanc-effective-meme/evaluate-yourself/.venv/lib/python3.14/site-packages/fastapi/routing.py:211: DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead
    is_coroutine = asyncio.iscoroutinefunction(dependant.call)

backend/app.py:544
  /Users/hchinnam/iceye-projects/copilot-worktrees/new_portfolio_2026/harisrujanc-effective-meme/evaluate-yourself/backend/app.py:544: DeprecationWarning: Call to '__init__' function with deprecated usage of input argument/s 'retry_on_timeout'. (TimeoutError is included by default.) -- Deprecated since version 6.0.0.
    _auth_token_service = TokenService(redis_client=get_redis_client())

backend/app.py:1507
  /Users/hchinnam/iceye-projects/copilot-worktrees/new_portfolio_2026/harisrujanc-effective-meme/evaluate-yourself/backend/app.py:1507: DeprecationWarning: `regex` has been deprecated, please use `pattern` instead
    interview_type: str = Query("technical", regex="^(technical|behavioral|mixed)$"),

backend/tests/test_route_surface_smoke.py::test_all_http_routes_respond_without_unhandled_server_errors
  /Users/hchinnam/iceye-projects/copilot-worktrees/new_portfolio_2026/harisrujanc-effective-meme/evaluate-yourself/.venv/lib/python3.14/site-packages/starlette/_utils.py:18: DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead
    callable(obj) and asyncio.iscoroutinefunction(obj.__call__)

backend/tests/test_route_surface_smoke.py::test_all_http_routes_respond_without_unhandled_server_errors
  /Users/hchinnam/iceye-projects/copilot-worktrees/new_portfolio_2026/harisrujanc-effective-meme/evaluate-yourself/.venv/lib/python3.14/site-packages/httpx/_client.py:690: DeprecationWarning: The 'app' shortcut is now deprecated. Use the explicit style 'transport=WSGITransport(app=...)' instead.
    warnings.warn(message, DeprecationWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
1 passed, 295 warnings in 4.57s
- .....                                                                    [100%]
=============================== warnings summary ===============================
.venv/lib/python3.14/site-packages/starlette/_utils.py:17: 112 warnings
backend/tests/test_startup_diagnostics.py: 1 warning
  /Users/hchinnam/iceye-projects/copilot-worktrees/new_portfolio_2026/harisrujanc-effective-meme/evaluate-yourself/.venv/lib/python3.14/site-packages/starlette/_utils.py:17: DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead
    return asyncio.iscoroutinefunction(obj) or (

backend/app.py:451
  /Users/hchinnam/iceye-projects/copilot-worktrees/new_portfolio_2026/harisrujanc-effective-meme/evaluate-yourself/backend/app.py:451: DeprecationWarning: 
          on_event is deprecated, use lifespan event handlers instead.
  
          Read more about it in the
          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
          
    @app.on_event("startup")

.venv/lib/python3.14/site-packages/fastapi/applications.py:4547
.venv/lib/python3.14/site-packages/fastapi/applications.py:4547
  /Users/hchinnam/iceye-projects/copilot-worktrees/new_portfolio_2026/harisrujanc-effective-meme/evaluate-yourself/.venv/lib/python3.14/site-packages/fastapi/applications.py:4547: DeprecationWarning: 
          on_event is deprecated, use lifespan event handlers instead.
  
          Read more about it in the
          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
          
    return self.router.on_event(event_type)

backend/app.py:459
  /Users/hchinnam/iceye-projects/copilot-worktrees/new_portfolio_2026/harisrujanc-effective-meme/evaluate-yourself/backend/app.py:459: DeprecationWarning: 
          on_event is deprecated, use lifespan event handlers instead.
  
          Read more about it in the
          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
          
    @app.on_event("shutdown")

.venv/lib/python3.14/site-packages/fastapi/routing.py:211: 108 warnings
  /Users/hchinnam/iceye-projects/copilot-worktrees/new_portfolio_2026/harisrujanc-effective-meme/evaluate-yourself/.venv/lib/python3.14/site-packages/fastapi/routing.py:211: DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead
    is_coroutine = asyncio.iscoroutinefunction(dependant.call)

backend/app.py:544
  /Users/hchinnam/iceye-projects/copilot-worktrees/new_portfolio_2026/harisrujanc-effective-meme/evaluate-yourself/backend/app.py:544: DeprecationWarning: Call to '__init__' function with deprecated usage of input argument/s 'retry_on_timeout'. (TimeoutError is included by default.) -- Deprecated since version 6.0.0.
    _auth_token_service = TokenService(redis_client=get_redis_client())

backend/app.py:1507
  /Users/hchinnam/iceye-projects/copilot-worktrees/new_portfolio_2026/harisrujanc-effective-meme/evaluate-yourself/backend/app.py:1507: DeprecationWarning: `regex` has been deprecated, please use `pattern` instead
    interview_type: str = Query("technical", regex="^(technical|behavioral|mixed)$"),

backend/tests/test_startup_diagnostics.py::test_favicon_route_returns_repo_managed_asset
  /Users/hchinnam/iceye-projects/copilot-worktrees/new_portfolio_2026/harisrujanc-effective-meme/evaluate-yourself/.venv/lib/python3.14/site-packages/starlette/_utils.py:18: DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead
    callable(obj) and asyncio.iscoroutinefunction(obj.__call__)

backend/tests/test_startup_diagnostics.py::test_favicon_route_returns_repo_managed_asset
  /Users/hchinnam/iceye-projects/copilot-worktrees/new_portfolio_2026/harisrujanc-effective-meme/evaluate-yourself/.venv/lib/python3.14/site-packages/httpx/_client.py:690: DeprecationWarning: The 'app' shortcut is now deprecated. Use the explicit style 'transport=WSGITransport(app=...)' instead.
    warnings.warn(message, DeprecationWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
5 passed, 229 warnings in 0.62s